### PR TITLE
Update FT8.h

### DIFF
--- a/FT8.h
+++ b/FT8.h
@@ -720,8 +720,8 @@
 
 
 /* FT81x graphics engine specific macros useful for static display list generation */
-#define BITMAP_LAYOUT_H(linestride,height) ((40UL<<24)|(((linestride)&3UL)<<2)|(((height)&3UL)<<0))
-#define BITMAP_SIZE_H(width,height) ((41UL<<24)|(((width)&3UL)<<2)|(((height)&3UL)<<0))
+#define BITMAP_LAYOUT_H(linestride,height) ((40UL<<24)|((((linestride&0xC00)>>10)&3UL)<<2)|((((height&0x600)>>9)&3UL)<<0))
+#define BITMAP_SIZE_H(width,height) ((41UL<<24)|((((width&0x600)>>9)&3UL)<<2)|((((height&0x600)>>9)&3UL)<<0))
 #define BITMAP_SOURCE(addr) ((1UL<<24)|(((addr)&4194303UL)<<0))
 #define NOP() ((45UL<<24))
 #define PALETTE_SOURCE(addr) ((42UL<<24)|(((addr)&4194303UL)<<0))


### PR DESCRIPTION
BITMAP_LAYOUT_H and BITMAP_SIZE_H macros incorrect for images over 512x512. i have corrected and tested on an ME813a

you need to take the upper 2 bits for each field, but the current macros are taking the lower 2