### PR TITLE
Definition file for platform IO inclusion

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "EVE Code Library",
-  "version": "0.1.0",
+  "version": "5.0.0",
   "description": "Code library for EVE2/EVE3/EVE4 graphics controller ICs from FTDI/Bridgetek",
   "keywords": "EVE,Bridgetek",
   "repository": {

--- a/library.json
+++ b/library.json
@@ -1,0 +1,21 @@
+{
+  "name": "EVE Code Library",
+  "version": "0.1.0",
+  "description": "Code library for EVE2/EVE3/EVE4 graphics controller ICs from FTDI/Bridgetek",
+  "keywords": "EVE,Bridgetek",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RudolphRiedel/FT800-FT813"
+  },
+  "authors": [
+    {
+      "name": "Rudolph Riedel"
+    }
+  ],
+  "license": "MIT",
+  "platforms": "espressif32",
+  "build": {
+    "srcDir": "",
+    "srcFilter": "-<example_pics/> -<example_projects/>"
+  }
+}

--- a/library.json
+++ b/library.json
@@ -13,9 +13,10 @@
     }
   ],
   "license": "MIT",
+  "framework": "arduino",
   "platforms": "espressif32",
   "build": {
-    "srcDir": "",
-    "srcFilter": "-<example_pics/> -<example_projects/>"
+    "srcDir": "example_projects/EVE_Test_Arduino_PlatformIO/src",
+    "srcFilter": "+<*.h> +<*.cpp>"
   }
 }


### PR DESCRIPTION
This allows adding this repository URL in the `lib_deps` section of the `platformio.ini` file while ensuring the example projects are not compiled. 
This is required because PlatformIO compiles all C/C++ file it finds, regardless of whether they are applicable to the currently targeted board or not.