### PR TITLE
Correct PCLK value for NHD 43 display

### DIFF
--- a/EVE_config.h
+++ b/EVE_config.h
@@ -487,7 +487,7 @@ typedef struct
 #if defined (EVE_NHD_43)
 #define Resolution_480x272
 
-#define EVE_PCLK (6L)
+#define EVE_PCLK (5L)
 #define EVE_PCLKPOL (1L)
 #define EVE_SWIZZLE (0L)
 #define EVE_CSPREAD (1L)


### PR DESCRIPTION
[[NHD-4.3-480272FT-CSXP-T.pdf](https://github.com/RudolphRiedel/FT800-FT813/files/14014445/NHD-4.3-480272FT-CSXP-T.pdf)
](https://newhavendisplay.com/content/specs/NHD-4.3-480272FT-CSXP-T.pdf)

According to the official document (I assume that "EVE_PCLK " is the same as "REG_PCLK" on the document), the correct value should be 5 instead of 6. Please see page 7 of this pdf file. 
![Screenshot 2024-01-22 140750](https://github.com/RudolphRiedel/FT800-FT813/assets/60754400/1cb2161d-386e-4bae-842d-ecbcfec76449)
