### PR TITLE
Set Frequency for NHD display

### DIFF
--- a/EVE_commands.c
+++ b/EVE_commands.c
@@ -1572,6 +1572,11 @@ static void enable_pixel_clock(void)
 {
     EVE_memWrite8(REG_GPIO, 0x80U); /* enable the DISP signal to the LCD panel, it is set to output in REG_GPIO_DIR by default */
 
+	/*NHD 4.3 display requires the PWM frequency between 800 to 10Khz. Default value for FT81x is 250. This has to be set or backlight won't turn on.*/
+#if defined (EVE_NHD_43)
+	EVE_memWrite16(REG_PWM_HZ,0x352);
+#endif
+
 #if (EVE_GEN > 3) && (defined EVE_PCLK_FREQ)
     EVE_memWrite16(REG_PCLK_FREQ, (uint16_t) EVE_PCLK_FREQ);
 

--- a/EVE_commands.c
+++ b/EVE_commands.c
@@ -1572,11 +1572,6 @@ static void enable_pixel_clock(void)
 {
     EVE_memWrite8(REG_GPIO, 0x80U); /* enable the DISP signal to the LCD panel, it is set to output in REG_GPIO_DIR by default */
 
-	/*NHD 4.3 display requires the PWM frequency between 800 to 10Khz. Default value for FT81x is 250. This has to be set or backlight won't turn on.*/
-#if defined (EVE_NHD_43)
-	EVE_memWrite16(REG_PWM_HZ,0x352);
-#endif
-
 #if (EVE_GEN > 3) && (defined EVE_PCLK_FREQ)
     EVE_memWrite16(REG_PCLK_FREQ, (uint16_t) EVE_PCLK_FREQ);
 

--- a/EVE_config.h
+++ b/EVE_config.h
@@ -294,6 +294,9 @@ typedef struct
 #define EVE_CSPREAD (0L)
 #define EVE_HAS_CRYSTAL
 #define EVE_GEN 2
+#if !defined (EVE_BACKLIGHT_FREQ)
+#define EVE_BACKLIGHT_FREQ (800U) /* if not overwritten in the project options, set 800Hz as a compromise */
+#endif
 #endif
 
 /* untested */
@@ -493,6 +496,9 @@ typedef struct
 #define EVE_CSPREAD (1L)
 #define EVE_HAS_CRYSTAL
 #define EVE_GEN 2
+#if !defined (EVE_BACKLIGHT_FREQ)
+#define EVE_BACKLIGHT_FREQ (800U) /* if not overwritten in the project options, set 800Hz as a compromise */
+#endif
 #endif
 
 /* untested */
@@ -580,6 +586,9 @@ typedef struct
 #define EVE_CSPREAD (1L)
 #define EVE_HAS_CRYSTAL
 #define EVE_GEN 2
+#if !defined (EVE_BACKLIGHT_FREQ)
+#define EVE_BACKLIGHT_FREQ (800U) /* if not overwritten in the project options, set 800Hz as a compromise */
+#endif
 #endif
 
 /* untested */
@@ -862,6 +871,9 @@ typedef struct
 #define EVE_CSPREAD (1L)
 #define EVE_HAS_CRYSTAL
 #define EVE_GEN 2
+#if !defined (EVE_BACKLIGHT_FREQ)
+#define EVE_BACKLIGHT_FREQ (800U) /* if not overwritten in the project options, set 800Hz as a compromise */
+#endif
 #endif
 
 /* FT810CB-HY50HD: FT810 800x480 5.0" HAOYU */


### PR DESCRIPTION
Backlight is controlled by two registers, REG_PWM_HZ and REG_PWM_DUTY. REG_PWM_HZ is default to 250 after reset. The range is between 250 and 10kHz.(See FT81x data sheet) The required frequency for NHD 4.3 FT812 display is between 800 and 10Khz. (Please see the NHD 4.3 display data sheet from my previous PR). 